### PR TITLE
Include all SQL exceptions in error string, not only the first

### DIFF
--- a/src/pdok/featured_to_extracts/api.clj
+++ b/src/pdok/featured_to_extracts/api.clj
@@ -105,7 +105,10 @@
             (swap! stats assoc-in [:processing worker-id] nil)
             (stats-on-callback callback-chan request run-stats)))
         (catch Exception e
-          (let [error-stats (merge request {:status "error" :msg (str e)})]
+          (let [error-str (if (instance? Iterable e)
+                            (clojure.string/join " Next: " (map str (seq e)))
+                            (str e))
+                error-stats (merge request {:status "error" :msg error-str})]
             (log/warn e error-stats)
             (swap! stats assoc-in [:processing worker-id] nil)
             (stats-on-callback callback-chan request error-stats)))


### PR DESCRIPTION
Database related issues may result in multiple SQLExceptions. Only the first exception message (often denoting a failed batch) is currently returned in the response body, hiding other (often more interesting) error messages also provided by the database.

related: PDOK/featured#31